### PR TITLE
Version 8.2.0: PHP v8.3.0 + Major fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v8.2.0
+* **[2024-01-12 05:58:13 CDT]** Remove Ubuntu's apt files to save space in the base image.
+* **[2024-01-07 09:30:00 CDT]** Fixed the building of the ioncube images.
+* **[2024-01-07 03:28:00 CDT]** [major] Fixed the broken web images.
+* **[2023-12-05 10:10:39 CDT]** Added PHP v8.3 support.
+* **[2023-12-05 10:09:40 CDT]** Added a PHP version test script.
+
 ## v8.1.0
 * **[2023-07-23 03:21:22 CDT]** Now Dockerize PHP will run in the container, if it's running, or create a temp one if it's not.
 * **[2023-05-19 05:35:27 CDT]** Updated to PHP v8.0.28, v8.1.19, and v8.2.6.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 Copyright (c) 2016 Donald Tyler
-Copyright (c) 2018-2023 Theodore R. Smith <theodore@phpexperts.pro>
+Copyright (c) 2018-2024 Theodore R. Smith <theodore@phpexperts.pro>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-PHP_VERSIONS="5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2"
-#PHP_VERSIONS="7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2"
-#PHP_VERSIONS="7.4 8.0 8.1 8.2"
+PHP_VERSIONS="5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3"
+#PHP_VERSIONS="7.4 8.0 8.1 8.2 8.3"
 #PHP_VERSIONS="8.2"
 cd images
 

--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -6,7 +6,7 @@ version: '3.6'
 #   https://github.com/phpexpertsinc/docker-php                     #
 #   License: MIT                                                    #
 #                                                                   #
-#   Copyright © 2018-2023 PHP Experts, Inc. <sales@phpexperts.pro>  #
+#   Copyright © 2018-2024 PHP Experts, Inc. <sales@phpexperts.pro>  #
 #       Author: Theodore R. Smith <theodore@phpexperts.pro>         #
 #      PGP Sig: 4BF826131C3487ACD28F2AD8EB24A91DD6125690            #
 #####################################################################

--- a/docker/images/base-debug/Dockerfile
+++ b/docker/images/base-debug/Dockerfile
@@ -5,7 +5,7 @@ ARG PHP_VERSION=8.0
 
 COPY xdebug.conf /tmp
 
-RUN apt-get install -y php${PHP_VERSION}-xdebug && \
+RUN apt-get -y update && apt-get install -y php${PHP_VERSION}-xdebug && \
     #
     # Configure XDebug
     cat /tmp/xdebug.conf >> /etc/php/${PHP_VERSION}/mods-available/xdebug.ini && \

--- a/docker/images/base-ioncube/Dockerfile
+++ b/docker/images/base-ioncube/Dockerfile
@@ -13,7 +13,6 @@ RUN cd /tmp && \
     printf  "[ioncube] \n \
 zend_extension=${EXT_DIR}/ioncube_loader_lin_${PHP_VERSION}.so\n" > /etc/php/${PHP_VERSION}/cli/conf.d/0-ioncube.ini && \
     mv -v ioncube/ioncube_loader_lin_${PHP_VERSION}.so $EXT_DIR/ && \
-    cp /etc/php/${PHP_VERSION}/cli/conf.d/0-ioncube.ini /etc/php/${PHP_VERSION}/fpm/conf.d/ && \
     rm -rf * && \
     #
     # Cleanup

--- a/docker/images/base/Dockerfile
+++ b/docker/images/base/Dockerfile
@@ -38,8 +38,8 @@ RUN apt-get install -y --no-install-recommends \
     # Cleanup
     apt-get autoremove -y && \
     apt-get clean && \
-    #rm -rf /var/lib/apt/lists/* && \
-    #rm -rf /var/cache/apt/* && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/apt/* && \
     #
     # Fix "Unable to create the PID file (/run/php/php5.6-fpm.pid).: No such file or directory (2)"
     mkdir -p /run/php

--- a/docker/images/web-debug/entrypoint.sh
+++ b/docker/images/web-debug/entrypoint.sh
@@ -9,8 +9,6 @@ if [ -f "/etc/nginx/custom/hosts" ]; then
   cat /etc/nginx/custom/hosts >> /etc/hosts
 fi
 
-INTERACTIVE=1 /usr/local/bin/entrypoint-php.sh
-
 if [ ! -z "$1" ]; then
     "$@"
     exit

--- a/docker/images/web-ioncube/Dockerfile
+++ b/docker/images/web-ioncube/Dockerfile
@@ -7,12 +7,27 @@ RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
         ca-certificates \
         nginx \
+        php${PHP_VERSION}-fpm \
         supervisor && \
 
+    ## Configure PHP-FPM
+    sed -i "s!display_startup_errors = Off!display_startup_errors = On!g" /etc/php/${PHP_VERSION}/fpm/php.ini && \
+    sed -i "s!memory_limit =.\+!memory_limit = -1!g" /etc/php/${PHP_VERSION}/cli/php.ini && \
+    sed -i "s!memory_limit =.\+!memory_limit = -1!g" /etc/php/${PHP_VERSION}/fpm/php.ini && \
+    sed -i "s!;error_log = php_errors.log!error_log = /proc/self/fd/2!g" /etc/php/${PHP_VERSION}/fpm/php.ini && \
+    sed -i "s!max_execution_time = 30!max_execution_time = 600!g" /etc/php/${PHP_VERSION}/fpm/php.ini && \
+    sed -i "s!session.gc_probability = 0!session.gc_probability = 1!g" /etc/php/${PHP_VERSION}/fpm/php.ini && \
+    #
+    sed -i "s!;daemonize = yes!daemonize = no!g" /etc/php/${PHP_VERSION}/fpm/php-fpm.conf && \
+    sed -i "s!error_log = /var/log/php${PHP_VERSION}-fpm.log!error_log = /proc/self/fd/2!g" /etc/php/${PHP_VERSION}/fpm/php-fpm.conf && \
+    #
+    sed -i "s!;catch_workers_output = yes!catch_workers_output = yes!g" /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf && \
+    sed -i "s!listen = /run/php/php${PHP_VERSION}-fpm.sock!listen = 0.0.0.0:9000!g" /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf && \
     # Route nginx logs to syslog socket (will show in Docker logs)
     sed -i 's!/var/log/nginx/access.log!syslog:server=unix:/dev/log!g' /etc/nginx/nginx.conf && \
     sed -i 's!/var/log/nginx/error.log!syslog:server=unix:/dev/log!g' /etc/nginx/nginx.conf && \
     ln -s /usr/sbin/php-fpm* /usr/sbin/php-fpm && \
+    cp /etc/php/${PHP_VERSION}/cli/conf.d/0-ioncube.ini /etc/php/${PHP_VERSION}/fpm/conf.d/ && \
 
     # Cleanup
     apt-get remove -y && \

--- a/docker/images/web-ioncube/entrypoint.sh
+++ b/docker/images/web-ioncube/entrypoint.sh
@@ -9,8 +9,6 @@ if [ -f "/etc/nginx/custom/hosts" ]; then
   cat /etc/nginx/custom/hosts >> /etc/hosts
 fi
 
-INTERACTIVE=1 /usr/local/bin/entrypoint-php.sh
-
 if [ ! -z "$1" ]; then
     "$@"
     exit

--- a/docker/images/web/entrypoint.sh
+++ b/docker/images/web/entrypoint.sh
@@ -9,8 +9,6 @@ if [ -f "/etc/nginx/custom/hosts" ]; then
   cat /etc/nginx/custom/hosts >> /etc/hosts
 fi
 
-INTERACTIVE=1 /usr/local/bin/entrypoint-php.sh
-
 if [ ! -z "$1" ]; then
     "$@"
     exit

--- a/install.php
+++ b/install.php
@@ -217,7 +217,7 @@ function getUserInput()
 }
 
 /**
- * Copyright © 2020-2023 Theodore R. Smith <https://www.phpexperts.pro/>
+ * Copyright © 2020-2024 Theodore R. Smith <https://www.phpexperts.pro/>
  * License: MIT
  *
  * @see https://stackoverflow.com/a/61168906/430062

--- a/test-versions.sh
+++ b/test-versions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+clear
+for VERSION in 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
+do
+    PHP_VERSION=$VERSION php --version
+done


### PR DESCRIPTION
* **[2024-01-12 05:58:13 CDT]** Remove Ubuntu's apt files to save space in the base image.
* **[2024-01-07 09:30:00 CDT]** Fixed the building of the ioncube images.
* **[2024-01-07 03:28:00 CDT]** [major] Fixed the broken web images.
* **[2023-12-05 10:10:39 CDT]** Added PHP v8.3 support.
* **[2023-12-05 10:09:40 CDT]** Added a PHP version test script.