### PR TITLE
v9.1.0: New zero-dependency Bash Installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### v9.1.0: New zero-dependency Bash Installer
+* **[2024-01-14 07:06:07 CDT]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
+* **[2024-01-14 07:04:47 CDT]** Added support for Linux ACLs in the base Linux image.
+* **[2024-01-14 07:03:35 CDT]** Fixed docker building bugs in base-oracle.
+
 ## v9.0.1
 * **[2024-01-14 06:40:56 CDT]** [major] Fixed a critical bug that prevented the dockerized php CLI from running in new projects. HEAD -> v9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,24 @@
 #### v9.1.0: New zero-dependency Bash Installer
-* **[2024-01-14 07:06:07 CDT]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
-* **[2024-01-14 07:04:47 CDT]** Added support for Linux ACLs in the base Linux image.
-* **[2024-01-14 07:03:35 CDT]** Fixed docker building bugs in base-oracle.
+* **[2024-01-14 07:06:07 CST]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
+* **[2024-01-14 07:04:47 CST]** Added support for Linux ACLs in the base Linux image.
+* **[2024-01-14 07:03:35 CST]** Fixed docker building bugs in base-oracle.
 
 ## v9.0.1
-* **[2024-01-14 06:40:56 CDT]** [major] Fixed a critical bug that prevented the dockerized php CLI from running in new projects. HEAD -> v9.0
+* **[2024-01-14 06:40:56 CST]** [major] Fixed a critical bug that prevented the dockerized php CLI from running in new projects. HEAD -> v9.0
 
 ## v9.0.0: Version 9.0.0: New full PHP image, Oracle ext-oci8, and a new build system.
-* **[2024-01-13 23:04:49 CDT]** Added the Oracle ext-oci8 binaries, built against Ubuntu 22.04.
-* **[2024-01-13 22:51:39 CDT]** Added a  docker build that contains the Oracle DB's ext-oci8 extension.
-* **[2024-01-13 22:50:16 CDT]** Added wget to the base PHP image.
-* **[2024-01-12 17:30:47 CDT]** Refactored IonCube builds so that the extension is only downloaded once.
-* **[2024-01-12 14:49:27 CDT]** Added a `full` docker build that contains every bundled PHP extension, and then some.
+* **[2024-01-13 23:04:49 CST]** Added the Oracle ext-oci8 binaries, built against Ubuntu 22.04.
+* **[2024-01-13 22:51:39 CST]** Added a  docker build that contains the Oracle DB's ext-oci8 extension.
+* **[2024-01-13 22:50:16 CST]** Added wget to the base PHP image.
+* **[2024-01-12 17:30:47 CST]** Refactored IonCube builds so that the extension is only downloaded once.
+* **[2024-01-12 14:49:27 CST]** Added a `full` docker build that contains every bundled PHP extension, and then some.
 
 ## v8.2.0
-* **[2024-01-12 05:58:13 CDT]** Removed Ubuntu's apt files to save space in the base image.
-* **[2024-01-07 09:30:00 CDT]** Fixed the building of the ioncube images.
-* **[2024-01-07 03:28:00 CDT]** [major] Fixed the broken web images.
-* **[2023-12-05 10:10:39 CDT]** Added PHP v8.3 support.
-* **[2023-12-05 10:09:40 CDT]** Added a PHP version test script.
+* **[2024-01-12 05:58:13 CST]** Removed Ubuntu's apt files to save space in the base image.
+* **[2024-01-07 09:30:00 CST]** Fixed the building of the ioncube images.
+* **[2024-01-07 03:28:00 CST]** [major] Fixed the broken web images.
+* **[2023-12-05 10:10:39 CST]** Added PHP v8.3 support.
+* **[2023-12-05 10:09:40 CST]** Added a PHP version test script.
 
 ## v8.1.0
 * **[2023-07-23 03:21:22 CDT]** Now Dockerize PHP will run in the container, if it's running, or create a temp one if it's not.

--- a/README.md
+++ b/README.md
@@ -80,26 +80,26 @@ Ensure that your profile PATH includes `./vendor/bin` and that it takes priority
 ## Latest Changes
 
 #### v9.1.0: New zero-dependency Bash Installer
-* **[2024-01-14 07:06:07 CDT]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
-* **[2024-01-14 07:04:47 CDT]** Added support for Linux ACLs in the base Linux image.
-* **[2024-01-14 07:03:35 CDT]** Fixed docker building bugs in base-oracle.
+* **[2024-01-14 07:06:07 CST]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
+* **[2024-01-14 07:04:47 CST]** Added support for Linux ACLs in the base Linux image.
+* **[2024-01-14 07:03:35 CST]** Fixed docker building bugs in base-oracle.
 
 #### v9.0.1:
 * **[2024-01-14 06:40:56 CDT]** [major] Fixed a critical bug that prevented the dockerized php CLI from running in new projects. HEAD -> v9.0
 
 #### v9.0.0: Version 9.0.0: New full PHP image, Oracle ext-oci8, and a new build system.
-* **[2024-01-13 23:04:49 CDT]** Added the Oracle ext-oci8 binaries, built against Ubuntu 22.04.
-* **[2024-01-13 22:51:39 CDT]** Added a  docker build that contains the Oracle DB's ext-oci8 extension.
-* **[2024-01-13 22:50:16 CDT]** Added wget to the base PHP image.
-* **[2024-01-12 17:30:47 CDT]** Refactored IonCube builds so that the extension is only downloaded once.
-* **[2024-01-12 14:49:27 CDT]** Added a `full` docker build that contains every bundled PHP extension, and then some.
+* **[2024-01-13 23:04:49 CST]** Added the Oracle ext-oci8 binaries, built against Ubuntu 22.04.
+* **[2024-01-13 22:51:39 CST]** Added a  docker build that contains the Oracle DB's ext-oci8 extension.
+* **[2024-01-13 22:50:16 CST]** Added wget to the base PHP image.
+* **[2024-01-12 17:30:47 CST]** Refactored IonCube builds so that the extension is only downloaded once.
+* **[2024-01-12 14:49:27 CST]** Added a `full` docker build that contains every bundled PHP extension, and then some.
 
 #### v8.2.0
-* **[2024-01-12 05:58:13 CDT]** Removed Ubuntu's apt files to save space in the base image.
-* **[2024-01-07 09:30:00 CDT]** Fixed the building of the ioncube images.
-* **[2024-01-07 03:28:00 CDT]** [major] Fixed the broken web images.
-* **[2023-12-05 10:10:39 CDT]** Added PHP v8.3 support.
-* **[2023-12-05 10:09:40 CDT]** Added a PHP version test script.
+* **[2024-01-12 05:58:13 CST]** Removed Ubuntu's apt files to save space in the base image.
+* **[2024-01-07 09:30:00 CST]** Fixed the building of the ioncube images.
+* **[2024-01-07 03:28:00 CST]** [major] Fixed the broken web images.
+* **[2023-12-05 10:10:39 CST]** Added PHP v8.3 support.
+* **[2023-12-05 10:09:40 CST]** Added a PHP version test script.
 
 #### v8.1.0
 * **[2023-07-23 03:21:22 CDT]** Now Dockerize PHP will run in the container, if it's running, or create a temp one if it's not.

--- a/README.md
+++ b/README.md
@@ -46,17 +46,25 @@ Out of the box, you have per-project binaries:
 
 * Watch the [**Installation HOWTO video**](https://youtu.be/xZxaJcsbrWU).
 
+## Via Bash (Zero PHP dependencies)
+
+    curl https://raw.githubusercontent.com/PHPExpertsInc/dockerize/master/install.sh | bash
+
 ### Via Composer
 
-    composer require phpexperts/dockerize
+    composer require --dev phpexperts/dockerize
     vendor/phpexperts/dockerize/install.php
     docker-compose up -d
 
-### Via GitHub
+### Via GitHub (Zero PHP dependencies)
+
+From inside your project's directory:
 
     git clone https://github.com/PHPExpertsInc/dockerize-php.git
-    cd docker-php-stack
-    bin/php install.php
+    mkdir -p ./vendor/bin
+    cp -r dockerize-php/bin/* ./vendor/bin/
+    chmod 0755 ./vendor/bin/composer ./vendor/bin/php
+    ./vendor/bin/php install.php
     docker-compose up -d
     
 Don't forget to edit your docker-compose.yml!

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Ensure that your profile PATH includes `./vendor/bin` and that it takes priority
 
 ## Latest Changes
 
+#### v9.1.0: New zero-dependency Bash Installer
+* **[2024-01-14 07:06:07 CDT]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
+* **[2024-01-14 07:04:47 CDT]** Added support for Linux ACLs in the base Linux image.
+* **[2024-01-14 07:03:35 CDT]** Fixed docker building bugs in base-oracle.
+
 #### v9.0.1:
 * **[2024-01-14 06:40:56 CDT]** [major] Fixed a critical bug that prevented the dockerized php CLI from running in new projects. HEAD -> v9.0
 

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -15,8 +15,15 @@ docker tag phpexperts/linux:latest phpexperts/linux:$(date '+%Y-%m-%d')
 
 # Download build assets
 ## IonCube
+echo "Downloading IonCube..."
 curl -LO https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz
 mv ioncube_loaders_lin_x86-64.tar.gz ./base-ioncube/.build-assets/
+# Oracle OCI8
+echo "Downloading Oracle's Instantclient + SDK..."
+curl -LO https://download.oracle.com/otn_software/linux/instantclient/2112000/instantclient-basic-linux.x64-21.12.0.0.0dbru.zip
+mv instantclient-basic-linux.x64-21.12.0.0.0dbru.zip ./base-oracle/.build-assets/
+curl -LO https://download.oracle.com/otn_software/linux/instantclient/2112000/instantclient-sdk-linux.x64-21.12.0.0.0dbru.zip
+mv instantclient-sdk-linux.x64-21.12.0.0.0dbru.zip ./base-oracle/.build-assets/
 
 for VERSION in ${PHP_VERSIONS}; do
   MAJOR_VERSION=${VERSION%.*}
@@ -40,8 +47,10 @@ for VERSION in ${PHP_VERSIONS}; do
   docker rmi --force phpexperts/php:${VERSION}-full
   docker build base-full  --tag="phpexperts/php:${VERSION}-full"           --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain
 
+  cp ~/.ssh/id_ed25519 base-oracle/.build-assets/
   docker rmi --force phpexperts/php:${VERSION}-oracle
   docker build base-oracle  --tag="phpexperts/php:${VERSION}-oracle"           --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain
+  rm -f base-oracle/.build-assets/id_ed25519
 
   docker build base-debug --tag="phpexperts/php:latest-debug"              --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain
   docker tag phpexperts/php:latest-debug "phpexperts/php:${MAJOR_VERSION}-debug"

--- a/docker/images/base-oracle/Dockerfile
+++ b/docker/images/base-oracle/Dockerfile
@@ -20,16 +20,15 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY .build-assets/${PHP_VERSION}/* \
      .build-assets/instantclient-basic-linux.x64-21.12.0.0.0dbru.zip \
      .build-assets/instantclient-sdk-linux.x64-21.12.0.0.0dbru.zip \
-     /tmp
+     /tmp/
 
 # Download oracle packages and install OCI8
 RUN mkdir -p /opt/oracle && \
     unzip /tmp/instantclient-basic-linux.x64-21.12.0.0.0dbru.zip && \
     mv instantclient_21_12    /opt/oracle/instantclient/ && \
-    rm /tmp/instantclient-basic-linux.x64-21.12.0.0.0dbru.zip && \
     unzip /tmp/instantclient-sdk-linux.x64-21.12.0.0.0dbru.zip  && \
     mv instantclient_21_12/*  /opt/oracle/instantclient/ && \
-    rm -r instantclient_21_12 /tmp/instantclient-sdk-linux.x64-21.12.0.0.0dbru.zip  && \
+    rm -r instantclient_21_12 /tmp/instantclient*  && \
     echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf && \
     ldconfig && \
     echo "Finished setting up the Oracle SDK."

--- a/docker/images/linux/Dockerfile
+++ b/docker/images/linux/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "Building base Linux..." && \
     #
     # Install PHP & curl (for composer)
     apt-get install -y --no-install-recommends \
-        curl git ssh wget \
+        curl git ssh wget acl \
         less vim inetutils-ping zip unzip net-tools
 
 WORKDIR /workdir

--- a/install.php
+++ b/install.php
@@ -56,17 +56,18 @@ YAML;
     }
 
     $dockerStub = str_replace('{{PHP_STUB}}', $newDockerCompose, $dockerStub);
+    echo "Current working directory: " . getcwd() . "\n";
     file_put_contents('docker-compose.yml', $dockerStub);
 }
 
 function choosePHPVersions()
 {
-    $PHP_VERSIONS = array_reverse(['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']);
+    $PHP_VERSIONS = array_reverse(['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']);
 
     $selection = '';
     $selectedChoices = [];
     while ($selection === '') {
-        echo "Choose PHP Versions (e.g., '1 3' for both $PHP_VERSIONS[0] and $PHP_VERSIONS[2]):\n";
+        echo "Choose PHP Web Versions (e.g., '1 3' for both $PHP_VERSIONS[0] and $PHP_VERSIONS[2]):\n";
         foreach ($PHP_VERSIONS as $index => $version) {
             ++$index;
             echo "$index) $version\n";

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+mkdir -p ./vendor/bin
+if [ ! -f ./vendor/bin/composer ]; then
+    wget https://raw.githubusercontent.com/PHPExpertsInc/dockerize/master/bin/composer -P vendor/bin
+    wget https://raw.githubusercontent.com/PHPExpertsInc/dockerize/master/bin/php -P vendor/bin
+    chmod 0755 ./vendor/bin/composer ./vendor/bin/php
+fi
+hash -r
+
+if ! echo $PATH | grep -q ./vendor/bin; then
+    echo 'You do not have ./vendor/bin in your $PATH.'
+    echo 'Modern PHP apps and phpexperts/dockerize require this.'
+
+    if [ ! -f ${HOME}/.bashrc ]; then
+        echo "ERROR: It doesn't look like you are using bash (no ~/.bashrc file)."
+        echo "       Please add ./vendor/bin to the PATH manually."
+        exit 1
+    fi
+
+    echo ''
+    echo -n 'May I add it to the front of your $PATH? (y/n) '
+    read YES_OR_NO
+    echo ''
+
+    if [ $YES_OR_NO == 'y' ]; then
+        echo 'Adding ./vendor/bin to your $PATH'
+        echo '# Added by phpexperts/dockerize' >> ~/.bashrc
+        echo 'PATH=./vendor/bin:$PATH' >> ~/.bashrc
+
+        echo 'Your $PATH has been updated. You need you start a new shell now.'
+        exit 2
+    else
+        echo "You can run Dockerized PHP manually:"
+        echo ""
+        echo "     ./vendor/bin/php"
+        echo "     ./vendor/bin/composer"
+    fi
+fi
+
+# See if they already have phpexperts/dockerize installed via composer...
+# If not, install it...
+composer show phpexperts/dockerize > /dev/null 2>&1 || composer require --ignore-platform-reqs --dev phpexperts/dockerize
+
+cp /code/dockerize/install.php vendor/phpexperts/dockerize
+./vendor/phpexperts/dockerize/bin/php ./vendor/phpexperts/dockerize/install.php
+


### PR DESCRIPTION
* **[2024-01-14 07:06:07 CDT]** Added a zero-PHP-dependency Bash installer. HEAD -> v9.1, master
* **[2024-01-14 07:04:47 CDT]** Added support for Linux ACLs in the base Linux image.
* **[2024-01-14 07:03:35 CDT]** Fixed docker building bugs in base-oracle.
